### PR TITLE
Support loading external files from HTTPS URLs

### DIFF
--- a/lib/capybara/driver/envjs_driver.rb
+++ b/lib/capybara/driver/envjs_driver.rb
@@ -171,12 +171,12 @@ class Capybara::Driver::Envjs < Capybara::Driver::Base
       browser.master["load"] = proc do |*args|
         if args.size == 2 and args[1].to_s != "[object split_global]"
           file, window = *args
+          uri = URI.parse(file)
           body = nil
-          if file.index(app_host) == 0
+          if uri.host.index(URI.parse(app_host).host) == 0
             get(file, {}, env)
             body = response.body
           else
-            uri = URI.parse(file)
             http = Net::HTTP.new(uri.host, uri.port)
             http.use_ssl = uri.scheme == 'https'
             response = http.request(Net::HTTP::Get.new(uri.request_uri))

--- a/lib/capybara/driver/envjs_driver.rb
+++ b/lib/capybara/driver/envjs_driver.rb
@@ -176,7 +176,11 @@ class Capybara::Driver::Envjs < Capybara::Driver::Base
             get(file, {}, env)
             body = response.body
           else
-            body = Net::HTTP.get(URI.parse(file))
+            uri = URI.parse(file)
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = uri.scheme == 'https'
+            response = http.request(Net::HTTP::Get.new(uri.request_uri))
+            body = response.body
           end
           window["evaluate"].call body
         else


### PR DESCRIPTION
A simple addition to allow fetching scripts using https.

Also only check the hostname part of the app_host in case the schemes don't match
